### PR TITLE
feat(database): backfill null values of name

### DIFF
--- a/db/migrations/20180117153013_backfill_movies_name.js
+++ b/db/migrations/20180117153013_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (Knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,6 +3,7 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
+  payload.name = payload.title;
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };


### PR DESCRIPTION
what: backfill null values of name and allow saving to both title and name columns
why: to continue our transition to change a column name from 'title' to 'name', saving to both title and name column from a create route