### PR TITLE
feat(database): add not-null to name and drop title

### DIFF
--- a/db/migrations/20180118103521_drop_title_from_movies.js
+++ b/db/migrations/20180118103521_drop_title_from_movies.js
@@ -1,0 +1,19 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name SET NOT NULL');
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ALTER COLUMN name DROP NOT NULL');
+  });
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      title: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,11 @@
 const Movie = require('../../../models/movie');
 
 exports.create = (payload) => {
-  payload.name = payload.title;
+  payload = {
+    id: payload.id,
+    name: payload.title,
+    release_year: payload.release_year
+  };
   return new Movie().save(payload)
   .then((movie) => new Movie({ id: movie.id }).fetch());
 };

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -12,12 +12,12 @@ describe('movie controller', () => {
 
       return Controller.create(payload)
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(payload.title);
 
         return new Movie({ id: movie.id }).fetch();
       })
       .then((movie) => {
-        expect(movie.get('title')).to.eql(payload.title);
+        expect(movie.get('name')).to.eql(payload.title);
       });
     });
 


### PR DESCRIPTION
what: add a not-null constraint to the name column and drop title column
why: we want to start saving incoming movie titles as name in the DB, and now that we've copied all titles to name we don't need the title column anymore